### PR TITLE
Generate Excellon_24 2.4 format files to avoid 10x scale

### DIFF
--- a/Eagle/CAM/MF_2_Layer.cam
+++ b/Eagle/CAM/MF_2_Layer.cam
@@ -32,7 +32,7 @@ Colors=" 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1 2 6 6 4 8 8 8 8 8 8 8 8 8 8 8 8 8 4 4 1 1
 [Sec_2]
 Name[en]="Drills&Holes"
 Prompt=""
-Device="EXCELLON"
+Device="EXCELLON_24"
 Wheel=""
 Rack=""
 Scale=1

--- a/Eagle/CAM/MF_4_Layer.cam
+++ b/Eagle/CAM/MF_4_Layer.cam
@@ -34,7 +34,7 @@ Colors=" 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1 2 6 6 4 8 8 8 8 8 8 8 8 8 8 8 8 8 4 4 1 1
 [Sec_2]
 Name[en]="Drills&Holes"
 Prompt=""
-Device="EXCELLON"
+Device="EXCELLON_24"
 Wheel=""
 Rack=""
 Scale=1

--- a/Eagle/CAM/MF_6_Layer.cam
+++ b/Eagle/CAM/MF_6_Layer.cam
@@ -36,7 +36,7 @@ Colors=" 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1 2 6 6 4 8 8 8 8 8 8 8 8 8 8 8 8 8 4 4 1 1
 [Sec_2]
 Name[en]="Drills&Holes"
 Prompt=""
-Device="EXCELLON"
+Device="EXCELLON_24"
 Wheel=""
 Rack=""
 Scale=1

--- a/Eagle/CAM/MF_8_Layer.cam
+++ b/Eagle/CAM/MF_8_Layer.cam
@@ -38,7 +38,7 @@ Colors=" 1 2 1 2 1 2 1 2 1 2 1 2 1 2 1 2 6 6 4 8 8 8 8 8 8 8 8 8 8 8 8 8 4 4 1 1
 [Sec_2]
 Name[en]="Drills&Holes"
 Prompt=""
-Device="EXCELLON"
+Device="EXCELLON_24"
 Wheel=""
 Rack=""
 Scale=1


### PR DESCRIPTION
The drill files generated by the Eagle CAM job get parsed as a 10x too large scale by the MacroFab application.
Choosing the EXCELLON_24 device (which is standard with Eagle) generates the proper 2.4 format data that gets parsed as proper size.
I have only tested this change on the 2 layer files, but it really should be the same for the 4/6/8.
